### PR TITLE
use map instead of list<pair>

### DIFF
--- a/src/main/kotlin/com/meetup/kotlinffm/dsl/http/Dsl.kt
+++ b/src/main/kotlin/com/meetup/kotlinffm/dsl/http/Dsl.kt
@@ -1,7 +1,7 @@
 package com.meetup.kotlinffm.dsl.http
 
 data class RequestBuilder(var method: HttpMethod = HttpMethod.GET) {
-    val headers = mutableListOf<Pair<String, String>>()
+    val headers = mutableMapOf<String, String>()
     var body: String? = null
 
     fun header(name: String, value: String) {

--- a/src/main/kotlin/com/meetup/kotlinffm/dsl/http/Models.kt
+++ b/src/main/kotlin/com/meetup/kotlinffm/dsl/http/Models.kt
@@ -2,7 +2,7 @@ package com.meetup.kotlinffm.dsl.http
 
 data class HttpRequest(
         val method: HttpMethod,
-        val headers: List<Pair<String, String>>,
+        val headers: Map<String, String>,
         val body: String?
 )
 


### PR DESCRIPTION
the order of the headers shouldn't really matter and using a map makes it slightly more readable